### PR TITLE
[geoclue-provider-mlsdb] Enable by default if positioning is enabled. Contributes to JB#34561

### DIFF
--- a/plugin/mlsdbprovider.cpp
+++ b/plugin/mlsdbprovider.cpp
@@ -474,7 +474,7 @@ bool MlsdbProvider::positioningEnabled()
     QSettings settings(LocationSettingsFile, QSettings::IniFormat);
     settings.beginGroup(QStringLiteral("location"));
     bool enabled = settings.value(QStringLiteral("enabled"), false).toBool();
-    bool cellIdPositioningEnabled = settings.value(QStringLiteral("cell_id_positioning_enabled"), false).toBool();
+    bool cellIdPositioningEnabled = settings.value(QStringLiteral("cell_id_positioning_enabled"), true).toBool();
     return enabled && cellIdPositioningEnabled;
 }
 


### PR DESCRIPTION
This commit makes the MLSDB positioning plugin assume that it is
enabled by default if the offline cell positioning setting has not
yet been set to either true or false, if positioning is enabled.

If the user has explicitly disabled offline cell positioning, or
positioning in general, then the MLSDB positioning plugin will still
be disabled.

Contributes to JB#34561