### PR TITLE
[geoclue-provider-mlsdb] Detect changes to location.conf. Contributes to JB#34743

### DIFF
--- a/plugin/mlsdbprovider.h
+++ b/plugin/mlsdbprovider.h
@@ -13,6 +13,7 @@
 #ifndef MLSDBPROVIDER_H
 #define MLSDBPROVIDER_H
 
+#include <QtCore/QFileSystemWatcher>
 #include <QtCore/QObject>
 #include <QtCore/QStringList>
 #include <QtCore/QBasicTimer>
@@ -104,7 +105,7 @@ signals:
 private Q_SLOTS:
     void setLocation(const Location &location);
     void serviceUnregistered(const QString &service);
-    void locationEnabledChanged();
+    void updatePositioningEnabled();
     void cellularNetworkRegistrationChanged();
 
 protected:
@@ -120,6 +121,8 @@ private:
     void calculatePositionAndEmitLocation();
     void populateCellIdToLocationMap();
 
+    QFileSystemWatcher m_locationSettingsWatcher;
+    bool m_positioningEnabled;
     bool m_positioningStarted;
     Status m_status;
     Location m_currentLocation;


### PR DESCRIPTION
This commit adds a QFileSystemWatcher to watch the location.conf file
for changes, so that the behaviour of the plugin dynamically reacts
to the user changing their location settings.

Upon being disabled while running, its positioning updates will become
disabled, and if not re-enabled within the QuitIdleTime (30s), the
plugin will exit.

Contributes to JB#34743