### PR TITLE
[geoclue-provider-mlsdb] Don't send empty online MLS request. Contributes to JB#36401

### DIFF
--- a/plugin/mlsdbonlinelocator.cpp
+++ b/plugin/mlsdbonlinelocator.cpp
@@ -95,7 +95,11 @@ bool MlsdbOnlineLocator::findLocation(const QList<MlsdbProvider::CellPositioning
     map.unite(globalFields());
     map.unite(cellTowerFields(cells));
     map.unite(wifiAccessPointFields());
-    map.unite(fallbackFields());
+    if (!map.isEmpty()) {
+        // If we have no data, the fallbacks are of minimal utility.
+        // e.g. the ip-fallback would at best give city-accuracy.
+        map.unite(fallbackFields());
+    }
 
     if (map.isEmpty()) {
         // no field data available


### PR DESCRIPTION
This commit ensures that we only send a request to the MLS server if
some data (e.g. nearby Cell Tower Ids or nearby Wireless LAN SSIDs)
are available.  Previously we would always set the fallbacks (which
includes the ip-fallback) which would produce some (very low accuracy)
result.

Contributes to JB#36401
