### PR TITLE
[geoclue-provider-mlsdb] Listen to config directory changes. Contributes to JB#36857

### DIFF
--- a/plugin/mlsdbprovider.cpp
+++ b/plugin/mlsdbprovider.cpp
@@ -40,6 +40,7 @@ namespace {
     const int FixTimeout = 30000;               // 30s
     const quint32 MinimumInterval = 10000;      // 10s
     const quint32 PreferredInitialFixTime = 0;  //  0s
+    const QString LocationSettingsDir = QStringLiteral("/etc/location/");
     const QString LocationSettingsFile = QStringLiteral("/etc/location/location.conf");
     const QString LocationSettingsEnabledKey = QStringLiteral("location/enabled");
     const QString LocationSettingsMlsEnabledKey = QStringLiteral("location/mls/enabled");
@@ -91,6 +92,9 @@ MlsdbProvider::MlsdbProvider(QObject *parent)
 
     connect(&m_locationSettingsWatcher, &QFileSystemWatcher::fileChanged,
             this, &MlsdbProvider::updatePositioningEnabled);
+    connect(&m_locationSettingsWatcher, &QFileSystemWatcher::directoryChanged,
+            this, &MlsdbProvider::updatePositioningEnabled);
+    m_locationSettingsWatcher.addPath(LocationSettingsDir);
     m_locationSettingsWatcher.addPath(LocationSettingsFile);
     updatePositioningEnabled();
 


### PR DESCRIPTION
When QSettings writes values to the settings file, it can perform
an atomic replacement via delete+rename.  This can result in missed
change signals if the QFileSystemWatcher is not watching the directory
but just the file.

This commit ensures that we listen to config directory changes as
well as config file changes.

Contributes to JB#36857