### PR TITLE
[geoclue-mlsdb] Suppress debug output to journal by default. Contributes to JB#38517

### DIFF
--- a/plugin/main.cpp
+++ b/plugin/main.cpp
@@ -18,9 +18,6 @@
 
 Q_DECL_EXPORT int main(int argc, char *argv[])
 {
-    QLoggingCategory::setFilterRules(QStringLiteral("geoclue.provider.mlsdb.debug=false\n"
-                                                    "geoclue.provider.mlsdb.position.debug=false"));
-
     QCoreApplication a(argc, argv);
     MlsdbProvider provider;
     QDBusConnection connection = QDBusConnection::sessionBus();

--- a/plugin/mlsdbonlinelocator.cpp
+++ b/plugin/mlsdbonlinelocator.cpp
@@ -22,6 +22,7 @@
 #include <QtNetwork/QNetworkRequest>
 #include <QtNetwork/QNetworkReply>
 #include <QtCore/QLoggingCategory>
+#include <QtGlobal>
 
 #include <sailfishkeyprovider.h>
 #include <qofonosimmanager.h>
@@ -36,7 +37,7 @@
  * See https://mozilla.github.io/ichnaea/api/geolocate.html for protocol documentation.
  */
 
-Q_LOGGING_CATEGORY(lcGeoclueMlsdbOnline, "geoclue.provider.mlsdb.online")
+Q_LOGGING_CATEGORY(lcGeoclueMlsdbOnline, "geoclue.provider.mlsdb.online", QtWarningMsg)
 
 MlsdbOnlineLocator::MlsdbOnlineLocator(QObject *parent)
     : QObject(parent)

--- a/plugin/mlsdbprovider.cpp
+++ b/plugin/mlsdbprovider.cpp
@@ -16,6 +16,7 @@
 #include "geoclue_adaptor.h"
 #include "position_adaptor.h"
 
+#include <QtGlobal>
 #include <QtCore/QLoggingCategory>
 #include <QtCore/QFile>
 #include <QtCore/QDir>
@@ -31,8 +32,8 @@
 #include <strings.h>
 #include <sys/time.h>
 
-Q_LOGGING_CATEGORY(lcGeoclueMlsdb, "geoclue.provider.mlsdb")
-Q_LOGGING_CATEGORY(lcGeoclueMlsdbPosition, "geoclue.provider.mlsdb.position")
+Q_LOGGING_CATEGORY(lcGeoclueMlsdb, "geoclue.provider.mlsdb", QtWarningMsg)
+Q_LOGGING_CATEGORY(lcGeoclueMlsdbPosition, "geoclue.provider.mlsdb.position", QtWarningMsg)
 
 namespace {
     MlsdbProvider *staticProvider = 0;


### PR DESCRIPTION
The default categorized logging behaviour doesn't suppress debug output
which leads to potentially sensitive (e.g., location) information being
logged to the journal.

This commit ensures that the debug category is turned off manually.

Contributes to JB#38517