### PR TITLE
[geoclue-provider-mlsdb] Do not request a location update with either incorrect or no information.

### DIFF
--- a/plugin/mlsdbonlinelocator.h
+++ b/plugin/mlsdbonlinelocator.h
@@ -55,6 +55,7 @@ private Q_SLOTS:
 private:
     bool readServerResponseData(const QByteArray &data, QString *errorString);
 
+    bool haveFieldData(const QList<MlsdbProvider::CellPositioningData> &cells);
     QVariantMap globalFields();
     QVariantMap cellTowerFields(const QList<MlsdbProvider::CellPositioningData> &cells);
     QVariantMap wifiAccessPointFields();

--- a/plugin/mlsdbprovider.cpp
+++ b/plugin/mlsdbprovider.cpp
@@ -366,10 +366,10 @@ QList<MlsdbProvider::CellPositioningData> MlsdbProvider::seenCellIds() const
                                : c->type() == QOfonoExtCell::WCDMA
                                ? MLSDB_CELL_TYPE_UMTS
                                : MLSDB_CELL_TYPE_UMTS;
-        if (c->cid() != -1 && c->cid() != 0) {
+        if (c->cid() != QOfonoExtCell::InvalidValue && c->cid() != 0) {
             locationCode = static_cast<quint32>(c->lac());
             cellId = static_cast<quint32>(c->cid());
-        } else if (c->ci() != -1 && c->ci() != 0) {
+        } else if (c->ci() != QOfonoExtCell::InvalidValue && c->ci() != 0) {
             locationCode = static_cast<quint32>(c->tac());
             cellId = static_cast<quint32>(c->ci());
         } else {

--- a/rpm/geoclue-providers-mlsdb.spec
+++ b/rpm/geoclue-providers-mlsdb.spec
@@ -1,5 +1,5 @@
 Name: geoclue-provider-mlsdb
-Version: 0.0.14
+Version: 0.0.15
 Release: 1
 Summary: Geoinformation Service from Mozilla Location Services Database Provider
 Group: System/Libraries


### PR DESCRIPTION
* [geoclue-provider-mlsdb] Do not request a location update with empty data. Contributes to JB#40427
* [geoclue-provider-mlsdb] Adjust to changed ofono API. Fixes JB#40427

First one avoids that we send empty requests to mozilla (and then them having to guess our location based on nothing).
Second one avoids sending -1 instead of trackingAreaCode/locationAreaCode & cellId in location requests.