### PR TITLE
[geoclue-provider-mlsdb] Cellular filter added. Contributes to JB#41839

### DIFF
--- a/plugin/mlsdbprovider.cpp
+++ b/plugin/mlsdbprovider.cpp
@@ -366,10 +366,10 @@ QList<MlsdbProvider::CellPositioningData> MlsdbProvider::seenCellIds() const
                                : c->type() == QOfonoExtCell::WCDMA
                                ? MLSDB_CELL_TYPE_UMTS
                                : MLSDB_CELL_TYPE_UMTS;
-        if (c->cid() != QOfonoExtCell::InvalidValue && c->cid() != 0) {
+        if (c->cid() != QOfonoExtCell::InvalidValue && c->cid() != 0 && mcc != 0) {
             locationCode = static_cast<quint32>(c->lac());
             cellId = static_cast<quint32>(c->cid());
-        } else if (c->ci() != QOfonoExtCell::InvalidValue && c->ci() != 0) {
+        } else if (c->ci() != QOfonoExtCell::InvalidValue && c->ci() != 0 && mcc != 0) {
             locationCode = static_cast<quint32>(c->tac());
             cellId = static_cast<quint32>(c->ci());
         } else {


### PR DESCRIPTION
When switching cellular modes, incorrect cell towers appear.
From the log: (type: 1 mcc: 0 mnc: 0 lac: 0 cellId: 4294967295 signal:0)
Therefore, suggest adding: "&& mcc != 0"