### PR TITLE
[geoclue-provider-mlsdb] Incorrect check cell and wifi. Contributes to JB#41843

### DIFF
--- a/plugin/mlsdbonlinelocator.cpp
+++ b/plugin/mlsdbonlinelocator.cpp
@@ -79,7 +79,7 @@ void MlsdbOnlineLocator::defaultVoiceModemChanged(const QString &modem)
 
 bool MlsdbOnlineLocator::haveFieldData(const QList<MlsdbProvider::CellPositioningData> &cells)
 {
-    return !(cells.isEmpty() && m_wifiServices.isEmpty() && (!m_simManager || !m_simManager->isValid()));
+    return !((cells.isEmpty() || !m_simManager || !m_simManager->isValid()) && m_wifiServices.isEmpty());
 }
 
 bool MlsdbOnlineLocator::findLocation(const QList<MlsdbProvider::CellPositioningData> &cells)


### PR DESCRIPTION
In the function: MlsdbOnlineLocator::haveFieldData, if the number of mobile cells and the number of wifi networks is zero, the request will still be sent