### PR TITLE
[geoclue-provider-mlsdb] Change location algorithm. Contributes to JB#41844

### DIFF
--- a/plugin/mlsdbonlinelocator.cpp
+++ b/plugin/mlsdbonlinelocator.cpp
@@ -63,6 +63,7 @@ MlsdbOnlineLocator::~MlsdbOnlineLocator()
 void MlsdbOnlineLocator::networkServicesChanged()
 {
     m_wifiServices = m_networkManager->getServices("wifi");
+    emit wifiChanged();
 }
 
 void MlsdbOnlineLocator::enabledModemsChanged(const QStringList &modems)

--- a/plugin/mlsdbonlinelocator.h
+++ b/plugin/mlsdbonlinelocator.h
@@ -44,6 +44,7 @@ public:
 signals:
     void locationFound(double latitude, double longitude, double accuracy);
     void error(const QString &errorString);
+    void wifiChanged();
 
 private Q_SLOTS:
     void networkServicesChanged();

--- a/plugin/mlsdbprovider.h
+++ b/plugin/mlsdbprovider.h
@@ -116,6 +116,7 @@ private Q_SLOTS:
     void cellularNetworkRegistrationChanged();
     void onlineLocationFound(double latitude, double longitude, double accuracy);
     void onlineLocationError(const QString &errorString);
+    void onlineWifiChanged();
 
 protected:
     void timerEvent(QTimerEvent *event) Q_DECL_OVERRIDE; // QObject
@@ -163,6 +164,9 @@ private:
     QBasicTimer m_idleTimer;    // qApp->quit() if positioning is off for long enough.
     QBasicTimer m_fixLostTimer; // after fix timeout, status set to Acquiring.  timer is reset when a position is calculated.
     QBasicTimer m_recalculatePositionTimer;
+
+    bool m_signalUpdateCell;
+    bool m_signalUpdateWiFi;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(MlsdbProvider::PositionFields)


### PR DESCRIPTION
In some phone models, the cellChanged signal is frequently triggered. Accordingly, this leads to a large number of requests and increased energy consumption. By default, the timer is triggered once every 10 seconds, which is enough to inaccurate positioning
In the timer added a check of cellular signals and wifi network. If not one has not triggered , then there are no further checks
In this case, we are reducing the number of unnecessary conversions and calculations