### PR TITLE
[geoclue-provider-mlsdb] Don't send empty requests even if fallbacks are enabled JB#41766

### DIFF
--- a/plugin/mlsdbonlinelocator.cpp
+++ b/plugin/mlsdbonlinelocator.cpp
@@ -102,7 +102,7 @@ bool MlsdbOnlineLocator::findLocation(const QList<MlsdbProvider::CellPositioning
     QVariantMap map;
     map.unite(cellTowerFields(cells));
     map.unite(wifiAccessPointFields());
-    if (map.isEmpty() && !m_fallbacksLacf && !m_fallbacksIpf) {
+    if (map.isEmpty()) {
         // no field data(cell, wifi) available
         qCDebug(lcGeoclueMlsdbOnline) << "No field data(cell, wifi) available for MLS online request";
         return false;


### PR DESCRIPTION
Fixed in JB#40427 but regressed in JB#41840.

The fallbacks should only be used when our data is not sufficient for
mozilla location services and not when we do not have any data (in
that case do not send a request yet).