### PR TITLE
[geoclue-provider-mlsdb] Cooperatively observe allowed data sources. Contributes to JB#33753

### DIFF
--- a/plugin/mlsdbonlinelocator.h
+++ b/plugin/mlsdbonlinelocator.h
@@ -35,9 +35,15 @@ class NetworkService;
 class MlsdbOnlineLocator : public QObject
 {
     Q_OBJECT
+
+    Q_PROPERTY(bool wlanDataAllowed READ wlanDataAllowed WRITE setWlanDataAllowed NOTIFY wlanDataAllowedChanged);
+
 public:
     explicit MlsdbOnlineLocator(QObject *parent = 0);
     ~MlsdbOnlineLocator();
+
+    bool wlanDataAllowed() const;
+    void setWlanDataAllowed(bool allowed);
 
     QPair<QDateTime, QVariantMap> buildLocationQuery(
         const QList<MlsdbProvider::CellPositioningData> &cells,
@@ -48,6 +54,7 @@ signals:
     void locationFound(double latitude, double longitude, double accuracy);
     void error(const QString &errorString);
     void wlanChanged();
+    void wlanDataAllowedChanged();
 
 private Q_SLOTS:
     void networkServicesChanged();
@@ -79,6 +86,8 @@ private:
 
     bool m_fallbacksLacf;
     bool m_fallbacksIpf;
+
+    bool m_wlanDataAllowed;
 
     mutable quint32 m_adaptiveInterval;
     mutable QVector<qint64> m_queryTimestamps;

--- a/plugin/mlsdbprovider.h
+++ b/plugin/mlsdbprovider.h
@@ -128,7 +128,9 @@ private:
     void startPositioningIfNeeded();
     void stopPositioningIfNeeded();
     void setStatus(Status status);
-    void getEnabled(bool *positioningEnabled, bool *cellPositioningEnabled, bool *onlinePositioningEnabled);
+    void getEnabled(bool *positioningEnabled, bool *cellPositioningEnabled,
+                    bool *onlinePositioningEnabled, bool *onlineDataAllowed,
+                    bool *cellDataAllowed, bool *wlanDataAllowed);
     quint32 minimumRequestedUpdateInterval() const;
     void calculatePositionAndEmitLocation();
 
@@ -138,6 +140,7 @@ private:
 
     QFileSystemWatcher m_locationSettingsWatcher;
     bool m_positioningEnabled;
+    bool m_cellDataAllowed;
     bool m_positioningStarted;
     Status m_status;
     Location m_currentLocation;
@@ -145,6 +148,8 @@ private:
 
     MlsdbOnlineLocator *m_mlsdbOnlineLocator;
     bool m_onlinePositioningEnabled;
+    bool m_onlineDataAllowed;
+    bool m_wlanDataAllowed;
     QPair<QDateTime, QVariantMap> m_previousQuery;
 
     QOfonoExtCellWatcher *m_cellWatcher;


### PR DESCRIPTION
The MDM API now supports explicitly enabling or disabling various
data sources which may be used by location plugins when performing
position determination.

This commit ensures that the MLSDB plugin cooperates with those
settings.

In the future, fine-grained access control and proper daemonised
API services will obviate the need for this PR to a large extent.