### PR TITLE
Temporarily disable online queries if api key fails. Fixes JB#48995

### DIFF
--- a/plugin/mlsdbonlinelocator.h
+++ b/plugin/mlsdbonlinelocator.h
@@ -18,6 +18,8 @@
 #include <QtCore/QVector>
 #include <QtCore/QTimer>
 
+#include <MGConfItem>
+
 #include "mlsdbprovider.h"
 
 QT_FORWARD_DECLARE_CLASS(QNetworkAccessManager)
@@ -35,8 +37,7 @@ class NetworkService;
 class MlsdbOnlineLocator : public QObject
 {
     Q_OBJECT
-
-    Q_PROPERTY(bool wlanDataAllowed READ wlanDataAllowed WRITE setWlanDataAllowed NOTIFY wlanDataAllowedChanged);
+    Q_PROPERTY(bool wlanDataAllowed READ wlanDataAllowed WRITE setWlanDataAllowed NOTIFY wlanDataAllowedChanged)
 
 public:
     explicit MlsdbOnlineLocator(QObject *parent = 0);
@@ -65,6 +66,7 @@ private Q_SLOTS:
 
 private:
     bool readServerResponseData(const QByteArray &data, QString *errorString);
+    void checkError(const QByteArray &data);
 
     QVariantMap globalFields() const;
     QVariantMap cellTowerFields(const QList<MlsdbProvider::CellPositioningData> &cells) const;
@@ -91,6 +93,8 @@ private:
 
     mutable quint32 m_adaptiveInterval;
     mutable QVector<qint64> m_queryTimestamps;
+
+    MGConfItem m_keyFailureTime;
 };
 
 #endif // MLSDBONLINELOCATOR_H

--- a/plugin/plugin.pro
+++ b/plugin/plugin.pro
@@ -8,7 +8,7 @@ target.path = /usr/libexec
 QT = core dbus network
 
 CONFIG += link_pkgconfig
-PKGCONFIG += qofono-qt5 qofonoext connman-qt5 libsailfishkeyprovider
+PKGCONFIG += qofono-qt5 qofonoext connman-qt5 libsailfishkeyprovider mlite5
 
 LIBS += -lrt
 

--- a/rpm/geoclue-provider-mlsdb.spec
+++ b/rpm/geoclue-provider-mlsdb.spec
@@ -15,6 +15,7 @@ BuildRequires: pkgconfig(qofonoext)
 BuildRequires: pkgconfig(connman-qt5)
 BuildRequires: pkgconfig(libsailfishkeyprovider)
 BuildRequires: pkgconfig(qt5-boostable)
+BuildRequires: pkgconfig(mlite5)
 Requires: mapplauncherd-qt5
 Requires: %{name}-agreements
 


### PR DESCRIPTION
Failure time written to dconf and preventing new tries for the next 12
hours.

@jpetrell @saukko 