### PR TITLE
Don't map unknown cell type to umts. JB#61599

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.o
+Makefile
+moc_*
+

--- a/plugin/mlsdbprovider.cpp
+++ b/plugin/mlsdbprovider.cpp
@@ -403,7 +403,11 @@ QList<MlsdbProvider::CellPositioningData> MlsdbProvider::seenCellIds() const
                                ? MLSDB_CELL_TYPE_GSM
                                : c->type() == QOfonoExtCell::WCDMA
                                ? MLSDB_CELL_TYPE_UMTS
-                               : MLSDB_CELL_TYPE_UMTS;
+                               : MLSDB_CELL_TYPE_OTHER;
+        if (cellType == MLSDB_CELL_TYPE_OTHER) {
+            qCDebug(lcGeoclueMlsdbPosition) << "ignoring cell with unknown type" << c->type();
+            continue;
+        }
         if (c->cid() != QOfonoExtCell::InvalidValue && c->cid() != 0 && mcc != 0) {
             locationCode = static_cast<quint32>(c->lac());
             cellId = static_cast<quint32>(c->cid());


### PR DESCRIPTION
    Now mapping the new NR type as UMTS. Likely the lack of cid and ci
    was making it hit the 'continue' case below, but maybe better
    not even attempt if the type is not handled. MLS data doesn't
    at the moment have NR.
